### PR TITLE
core - resolves #8 | Setup CHANNEL_CONNECTINFO in settings.py

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -113,8 +113,16 @@ DEFAULT_CHANNELS = [
     {"key": "MudInfo",
      "aliases": "",
      "desc": "Connection log",
-     "locks": "control:perm(Developer);listen:perm(Admin);send:false()"}
+     "locks": "control:perm(Developer);listen:perm(Admin);send:false()"},
+    {"key": "ConnInfo",
+     "aliases": "",
+     "desc": "Connection log",
+     "locks": "control:perm(Developer);listen:all();send:false()"}
 ]
+
+# Extra optional channel for receiving connection messages ("<account> has (dis)connected").
+# While the MudInfo channel will also receieve this, this channel is meant for non-staffers.
+CHANNEL_CONNECTINFO = ["ConnInfo"]
 
 ######################################################################
 # Settings given in secret_settings.py override those in this file.


### PR DESCRIPTION
This channel, ConnInfo, seems to have way too much information in it and doubles up channel tag information.  Improvements will be pitched upstream, but the part that causes the need for a db wipe is done which was what was important on this task.